### PR TITLE
Sort out whitespace issue.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,10 @@ var S = require('string');
  */
 module.exports = function(strings, toStrings) {
   // validate that string matches toStrings in the first place.
-  if (sanitize(strings.join(' ')) != sanitize(toStrings.join(' '))) {
+  var one = strings.map(function(s){ return sanitize(s).replace(/ /g, '');}).join(''),
+      two = toStrings.map(function(s){ return sanitize(s).replace(/ /g, '');}).join('');
+
+  if ( one != two) {
     return false;
   }
 
@@ -49,11 +52,11 @@ module.exports = function(strings, toStrings) {
 };
 
 function sanitize(text) {
-  return S(text || '').stripTags().decodeHTMLEntities().trim().collapseWhitespace().s;
+  return S(text || '').stripTags().decodeHTMLEntities().collapseWhitespace().s;
 }
 function splitIntoWords(text) {
   text = sanitize(text);
   if (!text.length) return []; // return empty array if empty string.
-  return text.split(/\s+/);
+  return text.split(/[\s\.]+/).filter(function(s) { return s.length; });
 }
 

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = function(strings, toStrings) {
 };
 
 function sanitize(text) {
-  return S(text || '').stripTags().decodeHTMLEntities().collapseWhitespace().s;
+  return S(text || '').stripTags().decodeHTMLEntities().trim().collapseWhitespace().s;
 }
 function splitIntoWords(text) {
   text = sanitize(text);

--- a/test/index.js
+++ b/test/index.js
@@ -35,11 +35,11 @@ describe('lib/map', function() {
       { segments: ['f'], more: false }
     ]);
   });
-  it('should handle differences in whitespace', function() {
+  it('should handle differences in whitespace around punctuation', function() {
     var out = map(['Hello Bob ...', 'You are great.'], ['Hello Bob', '...You are great.']);
     expect(out).to.eql([
-      { segments: ['Hello Bob'], more: true },
-      { segments: ['...', 'You are great.'], more: false }
+      { segments: ['Hello Bob'], more: false },
+      { segments: ['You are great'], more: false }
     ]);
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -35,4 +35,11 @@ describe('lib/map', function() {
       { segments: ['f'], more: false }
     ]);
   });
+  it('should handle differences in whitespace', function() {
+    var out = map(['Hello Bob ...', 'You are great.'], ['Hello Bob', '...You are great.']);
+    expect(out).to.eql([
+      { segments: ['Hello Bob'], more: true },
+      { segments: ['...', 'You are great.'], more: false }
+    ]);
+  });
 });


### PR DESCRIPTION
Steps to reproduce the issue in Content Samurai:
Have a script like this:

```
My name is Bob ...
And I like fishing.
```

Then in your slides, break/merge so the slides are:

```
My name is Bob
...And I like fishing.
```

The timing task will fail based on the 'do not match' check returning `false`.
This seeks to correct this problem.
